### PR TITLE
Update curlftpfs_0.9.2.bb

### DIFF
--- a/recipes/fuse/curlftpfs_0.9.2.bb
+++ b/recipes/fuse/curlftpfs_0.9.2.bb
@@ -4,13 +4,13 @@ HOMEPAGE = "http://curlftpfs.sourceforge.net/"
 SECTION = "console/network"
 PRIORITY = "optional"
 LICENSE = "GPLv2"
-DEPENDS = "glib-2.0 fuse curl"
+DEPENDS = "glib-2.0 fuse curl pkgconfig"
 RDEPENDS_${PN} += " libcurl "
 PR = "r1"
 
-SRC_URI = "${SOURCEFORGE_MIRROR}/curlftpfs/${P}.tar.gz"
+SRC_URI = "${SOURCEFORGE_MIRROR}/curlftpfs/${BP}.tar.gz"
 
-S = "${WORKDIR}/${P}"
+S = "${WORKDIR}/${BP}"
 
 inherit autotools
 


### PR DESCRIPTION
LIC_FILES_CHKSUM should be added. and we depend on pkgconfig to prevent configuration error